### PR TITLE
Stay in one transaction, account for accessing new name, fixes #50

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -83,10 +83,6 @@ podcast-feed-gen. That's also why it's a bit clunky.
    > exit()
    ```
 
-4. Populate by running:
-
-   `py.test webserver/test_api.py`
-
 5. Populate with old urls by running:
 
    `python -m webserver.alternate_show_names`


### PR DESCRIPTION
And simplify populating the urlredirect database by
creating the canonical slugs if they don't exist yet.