### PR TITLE
Implement default podcast image, fixes #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This project uses Python v3.4 only, and is written so that the podcast feeds can
 
 ## Changelog ##
 
+* October 2nd 2016: New show metadata source; requires new section in `settings.py`
+
 ### 0.2 (not released yet) ###
 
 * Lots of improvements

--- a/generator/metadata_sources/__init__.py
+++ b/generator/metadata_sources/__init__.py
@@ -11,6 +11,7 @@ from .show.manual_changes import ManualChanges as ManualChangesShow
 from .episode.manual_changes import ManualChanges as ManualChangesEpisode
 from .episode.radiorevolt_no import RadioRevolt_no as RadioRevolt_noEpisode
 from .show.radiorevolt_no import RadioRevolt_no as RadioRevolt_noShow
+from .show.default_image import SetDefaultImageURL
 
 """Metadata sources.
 
@@ -41,5 +42,6 @@ EPISODE_METADATA_SOURCES = [
 SHOW_METADATA_SOURCES = [
     ChimeraShow,
     # RadioRevolt_noShow,
-    ManualChangesShow
+    ManualChangesShow,
+    SetDefaultImageURL,
 ]

--- a/generator/metadata_sources/show/default_image.py
+++ b/generator/metadata_sources/show/default_image.py
@@ -1,0 +1,23 @@
+from .. import ShowMetadataSource
+import warnings
+
+
+class SetDefaultImageURL(ShowMetadataSource):
+    """A metadata source for shows, which sets its image to a default if it's
+    not set."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.has_default_image = 'IMAGE' in self.settings
+        if not self.has_default_image:
+            warnings.warn("SetDefaultImageURL is in use as a metadata source,"
+                          " but there is no default image set in settings.py. "
+                          "Key: IMAGE, value: absolute URL to the default "
+                          "image.")
+
+    def accepts(self, show) -> bool:
+        return super().accepts(show) \
+               and self.has_default_image \
+               and not show.image
+
+    def populate(self, show) -> None:
+        show.image = self.settings['IMAGE']

--- a/generator/settings_template.py
+++ b/generator/settings_template.py
@@ -140,7 +140,11 @@ METADATA_SOURCE = {
         # Path to the configuration file used by ManualChanges for shows.
         # Default is metadata_sources/show/manual_changes.json (relative to this directory).
         'SHOW_CONFIG': os.path.join(os.path.dirname(__file__), "metadata_sources", "show", "manual_changes.json"),
-    }
+    },
+    'SetDefaultImageURL': {
+        # Absolute URL to the default image
+        'IMAGE': "http://example.com/default.png",
+    },
 
 }
 


### PR DESCRIPTION
This is implemented as a new show metadata source, which
populates shows with no image yet.

This change requires configuration for the new metadata source,
so it can know what the default image shall be. See the change
for generator/settings_template.py.